### PR TITLE
엔티티별 레포지토리 구현 및 session 의존성 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-    implementation 'org.springframework.session:spring-session-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'software.amazon.awssdk:s3:2.25.0'

--- a/src/main/java/com/techup/spring/spring_be/repository/ChatRepository.java
+++ b/src/main/java/com/techup/spring/spring_be/repository/ChatRepository.java
@@ -1,4 +1,12 @@
 package com.techup.spring.spring_be.repository;
 
-public class ChatRepository {
+import com.techup.spring.spring_be.domain.Chat;
+import com.techup.spring.spring_be.domain.ChattingRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+    Page<Chat> findByRoomOrderByCreatedAtDesc(ChattingRoom room, Pageable pageable);
 }

--- a/src/main/java/com/techup/spring/spring_be/repository/ChattingRoomRepository.java
+++ b/src/main/java/com/techup/spring/spring_be/repository/ChattingRoomRepository.java
@@ -1,4 +1,11 @@
 package com.techup.spring.spring_be.repository;
 
-public class ChattingRoomRepository {
+import com.techup.spring.spring_be.domain.ChattingRoom;
+import com.techup.spring.spring_be.domain.Community;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChattingRoomRepository extends JpaRepository<ChattingRoom, Long> {
+
+    List<ChattingRoom> findByCommunity(Community community);
 }

--- a/src/main/java/com/techup/spring/spring_be/repository/CommentRepository.java
+++ b/src/main/java/com/techup/spring/spring_be/repository/CommentRepository.java
@@ -1,4 +1,11 @@
 package com.techup.spring.spring_be.repository;
 
-public class CommentRepository {
+import com.techup.spring.spring_be.domain.Comment;
+import com.techup.spring.spring_be.domain.Post;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByPost(Post post);
 }

--- a/src/main/java/com/techup/spring/spring_be/repository/CommunityRepository.java
+++ b/src/main/java/com/techup/spring/spring_be/repository/CommunityRepository.java
@@ -1,4 +1,8 @@
 package com.techup.spring.spring_be.repository;
 
-public class CommunityRepository {
+import com.techup.spring.spring_be.domain.Community;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommunityRepository extends JpaRepository<Community, Long>{
+
 }

--- a/src/main/java/com/techup/spring/spring_be/repository/FavoriteRepository.java
+++ b/src/main/java/com/techup/spring/spring_be/repository/FavoriteRepository.java
@@ -1,4 +1,16 @@
 package com.techup.spring.spring_be.repository;
 
-public class FavoriteRepository {
+import com.techup.spring.spring_be.domain.Favorite;
+import com.techup.spring.spring_be.domain.Post;
+import com.techup.spring.spring_be.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    boolean existsByUserAndPost(User user, Post post);
+
+    Optional<Favorite> findByUserAndPost(User user, Post post);
+
+    long countByPost(Post post);
 }

--- a/src/main/java/com/techup/spring/spring_be/repository/PostRepository.java
+++ b/src/main/java/com/techup/spring/spring_be/repository/PostRepository.java
@@ -1,4 +1,12 @@
 package com.techup.spring.spring_be.repository;
 
-public class PostRepository {
+import com.techup.spring.spring_be.domain.Community;
+import com.techup.spring.spring_be.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findByCommunity(Community community, Pageable pageable);
 }

--- a/src/main/java/com/techup/spring/spring_be/repository/UserRepository.java
+++ b/src/main/java/com/techup/spring/spring_be/repository/UserRepository.java
@@ -1,4 +1,12 @@
 package com.techup.spring.spring_be.repository;
 
-public class UserRepository {
+import com.techup.spring.spring_be.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long>{
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,3 @@ spring:
 
   application:
     name: spring-be
-
-  session:
-    store-type: none


### PR DESCRIPTION
spring session 의존성 제거 및 application.yml 파일 수정
엔티티 별로 레포지토리 구현
인터페이스로 구현한 이유
1. Spring Data JPA가 자동으로 구현체를 만들어주기 때문
2. 유지보수와 테스트가 훨씬 쉬워짐
3. JPA의 “관심 분리(Separation of concerns)” 설계 원칙